### PR TITLE
Properly escape the pep8 sample

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -306,7 +306,7 @@ The `Port Allocator Plugin <https://wiki.jenkins-ci.org/display/JENKINS/Port+All
 Static Code Analysis
 --------------------
 
-Pep8/Flake8:
+Pep8/Flake8::
 
   timeout(time: 5, unit: 'MINUTES') {
     sh 'bin/code-analysis'


### PR DESCRIPTION
A missing : was leading to the sample not being properly formatted.